### PR TITLE
Create ORT Error and Violation Attributions

### DIFF
--- a/reporter/src/funTest/kotlin/reporters/OpossumReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/OpossumReporterFunTest.kt
@@ -51,7 +51,7 @@ class OpossumReporterFunTest : WordSpec({
             val reportTree = JsonMapper().readTree(reportStr)
             reportTree.isObject shouldBe true
             reportTree.get("metadata").get("projectId").asText() shouldBe "0"
-            reportTree.get("attributionBreakpoints").size() shouldBe 5
+            reportTree.get("attributionBreakpoints").size() shouldBe 6
             reportTree.get("resourcesToAttributions").fieldNames().asSequence().toList() shouldContain "/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle/testCompile/junit/junit@4.12/dependencies/com.foobar/foobar@1.0"
         }
     }

--- a/reporter/src/funTest/kotlin/reporters/OpossumReporterFunTest.kt
+++ b/reporter/src/funTest/kotlin/reporters/OpossumReporterFunTest.kt
@@ -24,9 +24,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldContain
 
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
@@ -51,7 +49,7 @@ class OpossumReporterFunTest : WordSpec({
             val reportTree = JsonMapper().readTree(reportStr)
             reportTree.isObject shouldBe true
             reportTree.get("metadata").get("projectId").asText() shouldBe "0"
-            reportTree.get("attributionBreakpoints").size() shouldBe 6
+            reportTree.get("attributionBreakpoints").size() shouldBe 5
             reportTree.get("resourcesToAttributions").fieldNames().asSequence().toList() shouldContain "/analyzer/src/funTest/assets/projects/synthetic/gradle/lib/build.gradle/testCompile/junit/junit@4.12/dependencies/com.foobar/foobar@1.0"
         }
     }

--- a/reporter/src/main/kotlin/reporters/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/OpossumReporter.kt
@@ -44,15 +44,25 @@ import java.util.zip.Deflater
 import kotlin.math.min
 
 fun pathResolve(left: String, right: String = "", is_dir_flag: Boolean? = null): String {
-    val isDir = is_dir_flag == true || (is_dir_flag == null && (if (right != "") {right} else {left}).last() == '/')
+    val isDir = is_dir_flag == true || (is_dir_flag == null && (if (right != "") {
+        right
+    } else {
+        left
+    }).last() == '/')
     return "/${left}/${right}"
-        .replace(Regex("/*$"), if (isDir) {"/"} else {""})
-        .replace(Regex("/+"),"/")
+        .replace(
+            Regex("/*$"), if (isDir) {
+                "/"
+            } else {
+                ""
+            }
+        )
+        .replace(Regex("/+"), "/")
         .ifEmpty { "/" }
 }
 
 fun pathResolve(pieces: List<String>): String {
-    return pieces.reduce{ right, left -> pathResolve(right, left) }
+    return pieces.reduce { right, left -> pathResolve(right, left) }
 }
 
 /**
@@ -67,7 +77,7 @@ class OpossumReporter : Reporter {
         const val OPTION_EXCLUDED_SCOPES = "scopes.excluded"
     }
 
-    data class OpossumSignal (
+    data class OpossumSignal(
         val source: String,
         val id: Identifier? = null,
         val url: String? = null,
@@ -116,7 +126,7 @@ class OpossumReporter : Reporter {
     }
 
     data class OpossumResources(
-        val tree: MutableMap<String,OpossumResources> = mutableMapOf()
+        val tree: MutableMap<String, OpossumResources> = mutableMapOf()
     ) {
         fun addResource(pathPieces: List<String>) {
             if (pathPieces.isEmpty()) {
@@ -126,7 +136,7 @@ class OpossumReporter : Reporter {
             val head = pathPieces.first()
             val tail = pathPieces.drop(1)
 
-            if (! tree.containsKey(head)) {
+            if (!tree.containsKey(head)) {
                 tree[head] = OpossumResources()
             }
             tree[head]!!.addResource(tail)
@@ -156,14 +166,14 @@ class OpossumReporter : Reporter {
             val head = pathPieces.first()
             val tail = pathPieces.drop(1)
 
-            if (! tree.containsKey(head)) {
+            if (!tree.containsKey(head)) {
                 return true
             }
             return tree[head]!!.isPathAFile(tail)
         }
 
         fun toJson(): Map<*, *> {
-            return tree.asSequence().associateBy (
+            return tree.asSequence().associateBy(
                 { it.key },
                 {
                     if (it.value.isFile()) {
@@ -176,8 +186,9 @@ class OpossumReporter : Reporter {
 
         fun toFileList(): Set<String> {
             return tree.asSequence()
-                .flatMap { e -> e.value.toFileList()
-                    .map { pathResolve(e.key, it, is_dir_flag = false) }
+                .flatMap { e ->
+                    e.value.toFileList()
+                        .map { pathResolve(e.key, it, is_dir_flag = false) }
                 }
                 .plus("/")
                 .toSet()
@@ -207,11 +218,11 @@ class OpossumReporter : Reporter {
         var resources: OpossumResources = OpossumResources(),
         var signals: MutableList<OpossumSignal> = mutableListOf(),
         var pathToSignal: SortedMap<String, SortedSet<UUID>> = sortedMapOf(),
-        var packageToRoot: SortedMap<Identifier, SortedMap<String,Int>> = sortedMapOf(),
+        var packageToRoot: SortedMap<Identifier, SortedMap<String, Int>> = sortedMapOf(),
         var attributionBreakpoints: SortedSet<String> = sortedSetOf(),
         var filesWithChildren: SortedSet<String> = sortedSetOf(),
         var frequentLicenses: SortedSet<OpossumFrequentLicense> = sortedSetOf(),
-        var baseUrlsForSources: SortedMap<String,String> = sortedMapOf()
+        var baseUrlsForSources: SortedMap<String, String> = sortedMapOf()
     ) {
         fun toJson(): Map<*, *> {
             return sortedMapOf(
@@ -224,9 +235,13 @@ class OpossumReporter : Reporter {
                     .map { it.toJson() }
                     .asSequence()
                     .flatMap { it.asSequence() }
-                    .associateBy ( { it.key }, { it.value } ),
+                    .associateBy({ it.key }, { it.value }),
                 "resourcesToAttributions" to pathToSignal.mapKeys {
-                    val trailingSlash = if (resources.isPathAFile(it.key)) { "" } else { "/" }
+                    val trailingSlash = if (resources.isPathAFile(it.key)) {
+                        ""
+                    } else {
+                        "/"
+                    }
                     "${it.key}${trailingSlash}"
                 },
                 "attributionBreakpoints" to attributionBreakpoints,
@@ -248,7 +263,7 @@ class OpossumReporter : Reporter {
         }
 
         fun addFileWithChildren(fileWithChildren: String) {
-            filesWithChildren.add(pathResolve(fileWithChildren, is_dir_flag =  true))
+            filesWithChildren.add(pathResolve(fileWithChildren, is_dir_flag = true))
         }
 
         fun addBaseURL(path: String, vcs: VcsInfo) {
@@ -259,10 +274,14 @@ class OpossumReporter : Reporter {
             }
 
             if (vcs.type == VcsType.GIT && (vcs.url.startsWith("https://github.com/") || vcs.url.startsWith("ssh://git@github.com/"))) {
-                val revision = if (vcs.revision != VcsInfo.EMPTY.revision) { vcs.revision } else { "HEAD" }
+                val revision = if (vcs.revision != VcsInfo.EMPTY.revision) {
+                    vcs.revision
+                } else {
+                    "HEAD"
+                }
                 val baseUrl = vcs.url
                     .replace("ssh://git@github.com/", "https://github.com/")
-                    .replace(Regex("\\.git$"),"")
+                    .replace(Regex("\\.git$"), "")
                     .plus("/tree/${revision}/${vcs.path}/{path}")
                 baseUrlsForSources[idFromPath] = baseUrl
             }
@@ -317,10 +336,16 @@ class OpossumReporter : Reporter {
             )
         }
 
-        fun addDependency(dependency: PackageReference, curatedPackages: SortedSet<CuratedPackage>, relRoot: String, level: Int = 1) {
+        fun addDependency(
+            dependency: PackageReference,
+            curatedPackages: SortedSet<CuratedPackage>,
+            relRoot: String,
+            level: Int = 1
+        ) {
             val dependencyId = dependency.id
             log.debug("$relRoot - $dependencyId - Dependency")
-            val dependencyPath = pathResolve(listOf(relRoot, dependencyId.namespace, "${dependencyId.name}@${dependencyId.version}"))
+            val dependencyPath =
+                pathResolve(listOf(relRoot, dependencyId.namespace, "${dependencyId.name}@${dependencyId.version}"))
 
             val dependencyPackage = curatedPackages
                 .find { curatedPackage -> curatedPackage.pkg.id == dependencyId }
@@ -333,7 +358,7 @@ class OpossumReporter : Reporter {
             if (dependency.dependencies.isNotEmpty()) {
                 val rootForDependencies = pathResolve(dependencyPath, "dependencies")
                 addAttributionBreakpoint(rootForDependencies)
-                dependency.dependencies.map { this.addDependency(it, curatedPackages, rootForDependencies, level + 1 ) }
+                dependency.dependencies.map { this.addDependency(it, curatedPackages, rootForDependencies, level + 1) }
             }
         }
 
@@ -349,13 +374,22 @@ class OpossumReporter : Reporter {
             }
         }
 
-        fun getRootForProject(project: Project, relRoot: String) : String {
+        fun getRootForProject(project: Project, relRoot: String): String {
             val vcsPath = pathResolve(relRoot, project.vcs.path)
             val definitionFilePath = pathResolve(relRoot, project.definitionFilePath)
-            return if (definitionFilePath.startsWith(vcsPath)) { vcsPath } else { relRoot }
+            return if (definitionFilePath.startsWith(vcsPath)) {
+                vcsPath
+            } else {
+                relRoot
+            }
         }
 
-        fun addProject(project: Project, curatedPackages: SortedSet<CuratedPackage>, excludedScopes: Set<String>, relRoot: String = "/") {
+        fun addProject(
+            project: Project,
+            curatedPackages: SortedSet<CuratedPackage>,
+            excludedScopes: Set<String>,
+            relRoot: String = "/"
+        ) {
             val projectId = project.id
             val definitionFilePath = pathResolve(relRoot, project.definitionFilePath)
             log.debug("$definitionFilePath - $projectId - Project")
@@ -375,11 +409,11 @@ class OpossumReporter : Reporter {
             addSignal(signalFromProject, definitionFilePath)
 
             project.scopes
-                .filter{ ! excludedScopes.contains(it.name) }
+                .filter { !excludedScopes.contains(it.name) }
                 .forEachIndexed { index, scope ->
-                log.debug("analyzerResultProject -> scope ${index + 1} of ${project.scopes.size}")
-                this.addDependencyScope(scope, curatedPackages, definitionFilePath)
-            }
+                    log.debug("analyzerResultProject -> scope ${index + 1} of ${project.scopes.size}")
+                    this.addDependencyScope(scope, curatedPackages, definitionFilePath)
+                }
         }
 
         private fun makeLostAndFoundPath(id: Identifier): String {
@@ -389,7 +423,7 @@ class OpossumReporter : Reporter {
         fun addScannerResult(id: Identifier, result: ScanResult, maxDepth: Int) {
             val scanner = "${result.scanner.name}@${result.scanner.version}"
             val roots = packageToRoot[id]
-            if (roots == null)  {
+            if (roots == null) {
                 log.info("No root for $id from $scanner")
                 return
             }
@@ -409,9 +443,9 @@ class OpossumReporter : Reporter {
             if (rootsBelowMaxDepth.isNotEmpty()) {
                 val pathsFromFindings = licenseFindings
                     .map { it.location.path }
-                    .union( copyrightFindings.map { it.location.path } )
+                    .union(copyrightFindings.map { it.location.path })
 
-                pathsFromFindings.forEach {pathFromFinding ->
+                pathsFromFindings.forEach { pathFromFinding ->
                     val copyright = copyrightFindings
                         .filter { it.location.path == pathFromFinding }
                         .distinct()
@@ -434,7 +468,7 @@ class OpossumReporter : Reporter {
                         license = license
                     )
                     this.addSignal(pathSignal,
-                        rootsBelowMaxDepth.map { pathResolve(it, pathFromFinding)}
+                        rootsBelowMaxDepth.map { pathResolve(it, pathFromFinding) }
                             .toSortedSet())
                 }
             }
@@ -462,7 +496,7 @@ class OpossumReporter : Reporter {
         }
 
         fun addScannerResults(id: Identifier, results: List<ScanResult>, maxDepth: Int) {
-            results.forEach{ this.addScannerResult(id, it, maxDepth) }
+            results.forEach { this.addScannerResult(id, it, maxDepth) }
         }
 
         fun addPackagesThatAreRootless(analyzerResultPackages: SortedSet<CuratedPackage>) {
@@ -517,7 +551,7 @@ class OpossumReporter : Reporter {
             opossumInput.addFrequentLicense(
                 shortName = it.id,
                 fullName = it.fullName,
-                defaultText =  licenseText
+                defaultText = licenseText
             )
         }
 
@@ -550,8 +584,8 @@ class OpossumReporter : Reporter {
         options: Map<String, String>
     ): List<File> {
 
-        val maxDepth = options.getOrDefault( OPTION_SCANNER_MAXDEPTH, "3" ).toInt()
-        val excludedScopes = options.getOrDefault( OPTION_EXCLUDED_SCOPES, "devDependencies,test" ).split(",").toSet()
+        val maxDepth = options.getOrDefault(OPTION_SCANNER_MAXDEPTH, "3").toInt()
+        val excludedScopes = options.getOrDefault(OPTION_EXCLUDED_SCOPES, "devDependencies,test").split(",").toSet()
         val opossumInput = generateOpossumInput(input.ortResult, excludedScopes, maxDepth)
 
         val outputFile = outputDir.resolve("opossum.input.json.gz")

--- a/reporter/src/main/kotlin/reporters/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/OpossumReporter.kt
@@ -590,7 +590,6 @@ class OpossumReporter : Reporter {
             issues.forEach { issue ->
                 opossumInput.addIssue(issue, identifier, "ORT-Analyzer-Issues")
             }
-
         }
 
         val scannerResults = ortResult.scanner?.results?.scanResults ?: return OpossumInput()
@@ -599,7 +598,7 @@ class OpossumReporter : Reporter {
             opossumInput.addScannerResults(entry.key, entry.value, maxDepth)
         }
 
-
+        // TODO: Also parse results from advisor and evaluator:
         // val advisorResult = ortResult.advisor?.result
         // val evaluatorResult = ortResult.evaluator?.result
 

--- a/reporter/src/main/kotlin/reporters/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/OpossumReporter.kt
@@ -75,6 +75,7 @@ class OpossumReporter : Reporter {
     companion object {
         const val OPTION_SCANNER_MAXDEPTH = "scanner.maxDepth"
         const val OPTION_EXCLUDED_SCOPES = "scopes.excluded"
+        const val FOLLOW_UP = "FOLLOW_UP"
     }
 
     data class OpossumSignal(
@@ -85,7 +86,7 @@ class OpossumReporter : Reporter {
         val copyright: String? = null,
         val comment: String? = null,
         val preselected: Boolean = false,
-        val followUp: Boolean = false,
+        val followUp: String? = null,
         val excludeFromNotice: Boolean = false,
         val uuid: UUID = UUID.randomUUID()
     ) {
@@ -508,7 +509,7 @@ class OpossumReporter : Reporter {
         }
 
         private fun addIssue(issue: OrtIssue, source: String) {
-            val signal = OpossumSignal(source, comment = issue.toString(), followUp = true, excludeFromNotice = true)
+            val signal = OpossumSignal(source, comment = issue.toString(), followUp = FOLLOW_UP, excludeFromNotice = true)
             addSignal(signal, "/ortIssues/issues")
         }
 

--- a/reporter/src/main/kotlin/reporters/OpossumReporter.kt
+++ b/reporter/src/main/kotlin/reporters/OpossumReporter.kt
@@ -75,7 +75,6 @@ class OpossumReporter : Reporter {
     companion object {
         const val OPTION_SCANNER_MAXDEPTH = "scanner.maxDepth"
         const val OPTION_EXCLUDED_SCOPES = "scopes.excluded"
-        const val FOLLOW_UP = "FOLLOW_UP"
     }
 
     data class OpossumSignal(
@@ -86,7 +85,7 @@ class OpossumReporter : Reporter {
         val copyright: String? = null,
         val comment: String? = null,
         val preselected: Boolean = false,
-        val followUp: String? = null,
+        val followUp: Boolean = false,
         val excludeFromNotice: Boolean = false,
         val uuid: UUID = UUID.randomUUID()
     ) {
@@ -111,7 +110,7 @@ class OpossumReporter : Reporter {
                     "url" to url,
 
                     "preSelected" to preselected,
-                    "followUp" to followUp,
+                    "followUp" to if (followUp) "FOLLOW_UP" else null,
                     "excludeFromNotice" to excludeFromNotice,
 
                     "comment" to comment
@@ -514,7 +513,7 @@ class OpossumReporter : Reporter {
                 roots.keys
             }
             val signal =
-                OpossumSignal(source, comment = issue.toString(), followUp = FOLLOW_UP, excludeFromNotice = true)
+                OpossumSignal(source, comment = issue.toString(), followUp = true, excludeFromNotice = true)
             addSignal(signal, paths.map { pathResolve(it) }.toSortedSet())
         }
 

--- a/reporter/src/test/kotlin/reporters/OpossumReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/OpossumReporterTest.kt
@@ -166,14 +166,14 @@ class OpossumReporterTest : WordSpec({
                     .filter { it.comment?.contains(Regex("Source-.*Message-")) == true }
             issuesFromFirstPackage.size shouldBe 4
             issuesFromFirstPackage.forEach {
-                it.followUp shouldBe "FOLLOW_UP"
+                it.followUp shouldBe true
                 it.excludeFromNotice shouldBe true
             }
 
             val issuesAttachedToFallbackPath = opossumInput.getSignalsForFile("/")
             issuesAttachedToFallbackPath.size shouldBe 1
             issuesAttachedToFallbackPath.forEach {
-                it.followUp shouldBe "FOLLOW_UP"
+                it.followUp shouldBe true
                 it.excludeFromNotice shouldBe true
                 it.comment shouldContain Regex("Source-.*Message-")
             }

--- a/reporter/src/test/kotlin/reporters/OpossumReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/OpossumReporterTest.kt
@@ -119,7 +119,8 @@ class OpossumReporterTest : WordSpec({
         }
 
         "some/file File added by SCANNER report should have signal with copyright" {
-            val signals = opossumInput.getSignalsForFile("/pom.xml/compile/first-package-group/first-package@0.0.1/some/file")
+            val signals =
+                opossumInput.getSignalsForFile("/pom.xml/compile/first-package-group/first-package@0.0.1/some/file")
             signals.size shouldBe 2
             val signal = signals
                 .find { it.source == "ORT-Scanner-SCANNER@1.2.3" }
@@ -140,7 +141,7 @@ class OpossumReporterTest : WordSpec({
         val opossumInputJson = opossumInput.toJson()
         "opossumInput JSON should have expected top level entries" {
             opossumInputJson.keys shouldContain "metadata"
-            (opossumInputJson["metadata"] as Map<*,*>).keys shouldContain "projectId"
+            (opossumInputJson["metadata"] as Map<*, *>).keys shouldContain "projectId"
             opossumInputJson.keys shouldContain "resources"
             opossumInputJson.keys shouldContain "externalAttributions"
             opossumInputJson.keys shouldContain "resourcesToAttributions"
@@ -163,7 +164,8 @@ class OpossumReporterTest : WordSpec({
 
     "generateOpossumInput() with excluded scopes" should {
         val result = createOrtResult()
-        val opossumInputWithExcludedScopes = OpossumReporter().generateOpossumInput(result, sortedSetOf("devDependencies"))
+        val opossumInputWithExcludedScopes =
+            OpossumReporter().generateOpossumInput(result, sortedSetOf("devDependencies"))
         val fileListWithExcludedScopes = opossumInputWithExcludedScopes.resources.toFileList()
 
         "exclude of scopes should work" {

--- a/reporter/src/test/kotlin/reporters/OpossumReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/OpossumReporterTest.kt
@@ -160,12 +160,19 @@ class OpossumReporterTest : WordSpec({
         }
 
         "ortIssues should exist and contain all issues" {
-            val ortIssuesPath = opossumInput.resources.tree.get("ortIssues")
-            ortIssuesPath?.isFile() shouldBe false
-            val issuesPath = ortIssuesPath?.tree?.get("issues")
-            issuesPath?.isFile() shouldBe true
-            val issues = opossumInput.getSignalsForFile("/ortIssues/issues")
-            issues.forEach {
+
+            val issuesFromFirstPackage =
+                opossumInput.getSignalsForFile("/pom.xml/compile/first-package-group/first-package@0.0.1")
+                    .filter { it.comment?.contains(Regex("Source-.*Message-")) == true }
+            issuesFromFirstPackage.size shouldBe 4
+            issuesFromFirstPackage.forEach {
+                it.followUp shouldBe "FOLLOW_UP"
+                it.excludeFromNotice shouldBe true
+            }
+
+            val issuesAttachedToFallbackPath = opossumInput.getSignalsForFile("/")
+            issuesAttachedToFallbackPath.size shouldBe 1
+            issuesAttachedToFallbackPath.forEach {
                 it.followUp shouldBe "FOLLOW_UP"
                 it.excludeFromNotice shouldBe true
                 it.comment shouldContain Regex("Source-.*Message-")
@@ -385,7 +392,7 @@ private fun createOrtResult(): OrtResult {
                     }
                 ).toSortedSet(),
                 issues = sortedMapOf(
-                    Identifier("Analyzer-Issues-12") to listOf(
+                    Identifier("Maven:first-package-group:first-package:0.0.1") to listOf(
                         OrtIssue(
                             source = "Source-1",
                             message = "Message-1"
@@ -394,7 +401,7 @@ private fun createOrtResult(): OrtResult {
                             message = "Message-2"
                         )
                     ),
-                    Identifier("Analyzer-Issue-3") to listOf(
+                    Identifier("unknown-identifier") to listOf(
                         OrtIssue(
                             source = "Source-3",
                             message = "Message-3"

--- a/reporter/src/test/kotlin/reporters/OpossumReporterTest.kt
+++ b/reporter/src/test/kotlin/reporters/OpossumReporterTest.kt
@@ -166,7 +166,7 @@ class OpossumReporterTest : WordSpec({
             issuesPath?.isFile() shouldBe true
             val issues = opossumInput.getSignalsForFile("/ortIssues/issues")
             issues.forEach {
-                it.followUp shouldBe true
+                it.followUp shouldBe "FOLLOW_UP"
                 it.excludeFromNotice shouldBe true
                 it.comment shouldContain Regex("Source-.*Message-")
             }


### PR DESCRIPTION
For all issues in the ORT Report, generate Error attributions.

An Error attribution in the Opossum UI is:

-  a signal with follow-up and exclude-from-notice
-  comment, describing the issue
-  no coordinates, no license
-  attached to the resources that have the issue

This includes issues from analyzer and from scanner.
We try to attach the issues to the corresponding root paths. As a fallback, we attach it to the root path `/`.